### PR TITLE
Add signed URLs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "superbig/craft3-imgix",
     "description": "Use Imgix with Craft",
     "type": "craft-plugin",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "keywords": [
         "craft",
         "cms",

--- a/src/config.php
+++ b/src/config.php
@@ -35,6 +35,8 @@ return [
     // Volume handles mapped to Imgix domains
     'imgixDomains'   => [],
 
+    // Imgix signed URLs token
+    'imgixSignedToken' => '',
 
     // Lazy load attribute prefix
     'lazyLoadPrefix' => '',

--- a/src/models/ImgixModel.php
+++ b/src/models/ImgixModel.php
@@ -186,6 +186,9 @@ class ImgixModel extends Model
 
             $this->builder = new UrlBuilder($domain);
             $this->builder->setUseHttps(true);
+            
+            if ($token = Imgix::$plugin->getSettings()->imgixSignedToken)
+                $this->builder->setSignKey($token);
 
             $this->imagePath  = $image->getUri();
             $this->transforms = $transforms;
@@ -206,6 +209,9 @@ class ImgixModel extends Model
 
             $this->builder = new UrlBuilder($domain);
             $this->builder->setUseHttps(true);
+            
+            if ($token = Imgix::$plugin->getSettings()->imgixSignedToken)
+                $this->builder->setSignKey($token);
 
             $this->imagePath      = $image;
             $this->transforms     = $transforms;

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -40,6 +40,13 @@ class Settings extends Model
      * @var string
      */
     public $imgixDomains = [];
+    
+    /**
+     * Imgix signed URLs token
+     *
+     * @var string
+     */
+    public $imgixSignedToken = '';
 
     /**
      * @var string
@@ -57,6 +64,8 @@ class Settings extends Model
         return [
             [ 'imgixDomains', 'array' ],
             [ 'imgixDomains', 'default', 'value' => [] ],
+            [ 'imgixSignedToken', 'string' ],
+            [ 'imgixSignedToken', 'default', 'value' => '' ],
             [ 'lazyLoadPrefix', 'string' ],
             [ 'lazyLoadPrefix', 'default', 'value' => '' ],
         ];

--- a/src/services/ImgixService.php
+++ b/src/services/ImgixService.php
@@ -192,6 +192,8 @@ class ImgixService extends Component
         if ( isset($domains[ $volume->handle ]) ) {
             $builder = new UrlBuilder($domains[ $volume->handle ]);
             $builder->setUseHttps(true);
+            if ($token = Imgix::$plugin->getSettings()->imgixSignedToken)
+                $builder->setSignKey($token);
             $url = UrlHelper::stripQueryString($builder->createURL($assetUri));
         }
 


### PR DESCRIPTION
If the signed URL token is supplied in the config, then set the sign key on the imgix UrlBuilder.