### PR TITLE
Update README for imgix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# Imgix plugin for Craft CMS 3.x
+<!-- ix-docs-ignore -->
+# imgix plugin for Craft CMS 3.x
 
-Use Imgix with Craft
+Use imgix with Craft
 
 ![Screenshot](resources/img/plugin-icon.png)
+
+---
+<!-- /ix-docs-ignore -->
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuring imgix](#configuring-imgix)
+- [Using imgix](#using-imgix)
+- [Lazy Loading](#lazy-loading)
+- [Roadmap](#roadmap)
 
 ## Requirements
 
@@ -14,32 +25,36 @@ To install the plugin, follow these instructions.
 
 1. Open your terminal and go to your Craft project:
 
-        cd /path/to/project
+    ```
+    cd /path/to/project
+    ```
 
 2. Then tell Composer to load the plugin:
 
-        composer require superbig/craft3-imgix
+    ```
+    composer require superbig/craft3-imgix
+    ```
 
-3. In the Control Panel, go to Settings → Plugins and click the “Install” button for Imgix.
+3. In the Control Panel, go to Settings → Plugins and click the “Install” button for imgix.
 
-## Configuring Imgix
+## Configuring imgix
 
 Copy `config.php` into Crafts `config` folder and rename it to `imgix.php`.
 
-Then map your Asset Source handle to your Imgix domain, according to the example.
+Then map your Asset Source handle to your imgix domain, according to the example.
 
-This plugin will lookup the Asset image's source handle, and figure out which Imgix domain to use. If a URL string is passed, it will use the first domain in the config file.
+This plugin will lookup the Asset image's source handle, and figure out which imgix domain to use. If a URL string is passed, it will use the first domain in the config file.
 
 ```php
 <?php
    return [
-       // Imgix API key
+       // imgix API key
        'apiKey'         => '',
 
-       // Volume handles mapped to Imgix domains
+       // Volume handles mapped to imgix domains
        'imgixDomains'   => [],
 
-       // Imgix signed URLs token
+       // imgix signed URLs token
        'imgixSignedToken' => '',
 
        // Lazy load attribute prefix
@@ -47,7 +62,7 @@ This plugin will lookup the Asset image's source handle, and figure out which Im
    ];
 ```
 
-## Using Imgix
+## Using imgix
 
 ```twig
 {% set transforms = [
@@ -125,13 +140,14 @@ return [
     ]
 ];
 ```
-## Lazy loading
+
+## Lazy Loading
 
 To replace `src` and `srcset` with `data-src` and `data-srcset` for lazy loading, add the `lazyLoad` attribute to to `transformImage()`.
 
 If you need to prefix with something other than `data-`, you can set the configuration value `lazyLoadPrefix` in `craft/config/imgix.php`.
 
-## Imgix Roadmap
+## Roadmap
 
 * Look into improving srcset/API
 * Look into built-in image editor and focal points 


### PR DESCRIPTION
Hi @sjelfull, I'm one of the front-end engineers over at imgix. We're currently working on a project to update the [Libraries page](https://docs.imgix.com/libraries) on our Docs site, to pull in more relevant information about our various libraries and 3rd-party plugins. Part of this project involves pulling README data directly from GitHub to display the detail page for each library, so we've been going through and [cleaning up the README files for our entire SDK](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aclosed+is%3Apr+user%3Aimgix+is%3Apublic+%22docs%3A%22+readme+author%3Asherwinski). The new detail page design looks like this:

![image](https://user-images.githubusercontent.com/609840/72920115-a7ae1500-3d16-11ea-8b0b-e3ccf4556885.png)

We'd also like to pull in content directly from README files for the 3rd-party plugins that we link to, if the README file is in good enough shape. We think the content in this file would be great to include, but we do have to make a few little tweaks in order to make it fit perfectly. The changes proposed in this PR cover the small amount of clean-up we'd like to see before we start pulling this content into our docs site directly.

- I've replaced "Imgix" with "imgix" in a bunch of places, just to match the official spelling of the product
- I wrapped the top section in `<!-- ix-docs-ignore -->` tags. These get ignored by GitHub, but the content inside this wrapper will be stripped out when we include the content in our own docs. This essentially lets us avoid including the same information (project name, description, sometimes build badges) twice at the top of every page.
- I went ahead and added a table of contents, just to spruce it up a bit.
- And I fixed a couple of bullet-nested codeblocks that GitHub's renderer handles just fine but other Markdown renderers choke on.

The updated Docs page for this plug-in will of course include a link to this repo, plus a link directly to superbig.co. Let me know what you think!