### PR TITLE
Make secure URLs work if imgix source is setup with path prefix

### DIFF
--- a/src/models/ImgixModel.php
+++ b/src/models/ImgixModel.php
@@ -185,6 +185,11 @@ class ImgixModel extends Model
 
             $domains = Imgix::$plugin->getSettings()->imgixDomains;
             $domain  = array_key_exists($sourceHandle, $domains) ? $domains[ $sourceHandle ] : null;
+            $domainParts = [];
+            if ($domain !== null) {
+                $domainParts = explode('/', $domain, 2);
+                $domain = $domainParts[0];
+            }
 
             $this->builder = new UrlBuilder($domain);
             $this->builder->setUseHttps(true);
@@ -193,7 +198,13 @@ class ImgixModel extends Model
                 $this->builder->setSignKey($token);
             }
 
-            $this->imagePath  = $image->getPath();
+            $imagePath = '';
+            if (count($domainParts) === 2) {
+                $imagePath = rtrim($domainParts[1], '/') . '/';
+            }
+            $imagePath .= $image->getPath();
+
+            $this->imagePath  = $imagePath;
             $this->transforms = $transforms;
 
             if (!empty($focalPoint)) {
@@ -209,6 +220,11 @@ class ImgixModel extends Model
             $domains     = Imgix::$plugin->getSettings()->imgixDomains;
             $firstHandle = reset($domains);
             $domain      = $domains[ $firstHandle ];
+            $domainParts = [];
+            if ($domain !== null) {
+                $domainParts = explode('/', $domain, 2);
+                $domain = $domainParts[0];
+            }
 
             $this->builder = new UrlBuilder($domain);
             $this->builder->setUseHttps(true);
@@ -216,7 +232,13 @@ class ImgixModel extends Model
             if ($token = Imgix::$plugin->getSettings()->imgixSignedToken)
                 $this->builder->setSignKey($token);
 
-            $this->imagePath      = $image;
+            $imagePath = '';
+            if (count($domainParts) === 2) {
+                $imagePath = rtrim($domainParts[1], '/') . '/';
+            }
+            $imagePath .= $image;
+
+            $this->imagePath      = $imagePath;
             $this->transforms     = $transforms;
             $this->defaultOptions = $defaultOptions;
             $this->transform($transforms);


### PR DESCRIPTION
This PR is trying to fix issue #12.
Before change:
![image](https://user-images.githubusercontent.com/798156/79394012-c539f600-7f76-11ea-884c-99059bbf8fee.png)

After change:
![image](https://user-images.githubusercontent.com/798156/79393775-4e9cf880-7f76-11ea-873e-29d889966c9e.png)
