### PR TITLE
update new Imgix purge endpoint

### DIFF
--- a/src/services/ImgixService.php
+++ b/src/services/ImgixService.php
@@ -33,7 +33,7 @@ class ImgixService extends Component
     // Public Methods
     // =========================================================================
 
-    const IMGIX_PURGE_ENDPOINT = 'https://api.imgix.com/v2/image/purger';
+    const IMGIX_PURGE_ENDPOINT = 'https://api.imgix.com/api/v1/purge';
 
     protected $builder;
 


### PR DESCRIPTION
https://docs.imgix.com/apis/management#purge-examples implements new endpoint for purging.  legacy endpoints will not be supported by Imgix after end of march. Also, new API keys of format "ak_***" don't work with legacy end point. This PR updates code with new end point.