### PR TITLE
Fallback to asset url in case the volume is not in imgixDomains

### DIFF
--- a/src/models/ImgixModel.php
+++ b/src/models/ImgixModel.php
@@ -189,6 +189,10 @@ class ImgixModel extends Model
             if ($domain !== null) {
                 $domainParts = explode('/', $domain, 2);
                 $domain = $domainParts[0];
+            } else {
+                // Domain isn't in imgixDomains, just passthrough the image
+                $this->transformed = $image;
+                return;
             }
 
             $this->builder = new UrlBuilder($domain);


### PR DESCRIPTION
I brought this up in #20; this adds support in case you have one volume that is in `imgixDomains` and one that is not.